### PR TITLE
upgrade bridge upgrade and prerequisites runners

### DIFF
--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   upgrade_provider:
     name: upgrade-provider
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Call upgrade provider action
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.8


### PR DESCRIPTION
During a bridge update, the `make build_sdks` step terminates the runner on this provider.
See: https://github.com/pulumi/pulumi-datadog/actions/runs/6387518686

~Also, perhaps pre-emptively, updates the Prerequisites runner.~  edit: since here are not failing Prerequisites jobs in Actions, this is not currently necessary.
