### PR TITLE
Update GitHubOrg to DataDog

### DIFF
--- a/provider/cmd/pulumi-resource-datadog/schema.json
+++ b/provider/cmd/pulumi-resource-datadog/schema.json
@@ -7,7 +7,7 @@
     ],
     "homepage": "https://pulumi.io",
     "license": "Apache-2.0",
-    "attribution": "This Pulumi package is based on the [`datadog` Terraform Provider](https://github.com/terraform-providers/terraform-provider-datadog).",
+    "attribution": "This Pulumi package is based on the [`datadog` Terraform Provider](https://github.com/DataDog/terraform-provider-datadog).",
     "repository": "https://github.com/pulumi/pulumi-datadog",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
@@ -36,7 +36,7 @@
         },
         "nodejs": {
             "packageDescription": "A Pulumi package for creating and managing Datadog resources.",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-datadog)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-datadog` repo](https://github.com/pulumi/pulumi-datadog/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-datadog` repo](https://github.com/terraform-providers/terraform-provider-datadog/issues).",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/DataDog/terraform-provider-datadog)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-datadog` repo](https://github.com/pulumi/pulumi-datadog/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-datadog` repo](https://github.com/DataDog/terraform-provider-datadog/issues).",
             "dependencies": {
                 "@pulumi/pulumi": "^3.0.0"
             },
@@ -50,7 +50,7 @@
             "requires": {
                 "pulumi": "\u003e=3.0.0,\u003c4.0.0"
             },
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-datadog)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-datadog` repo](https://github.com/pulumi/pulumi-datadog/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-datadog` repo](https://github.com/terraform-providers/terraform-provider-datadog/issues).",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/DataDog/terraform-provider-datadog)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-datadog` repo](https://github.com/pulumi/pulumi-datadog/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-datadog` repo](https://github.com/DataDog/terraform-provider-datadog/issues).",
             "compatibility": "tfbridge20",
             "pyproject": {
                 "enabled": true

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -82,6 +82,7 @@ func Provider() tfbridge.ProviderInfo {
 		MetadataInfo:     tfbridge.NewProviderMetadata(metadata),
 		Version:          version.Version,
 		UpstreamRepoPath: "./upstream",
+		GitHubOrg:        "DataDog",
 		DocRules:         &tfbridge.DocRuleInfo{EditRules: docEditRules},
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"datadog_dashboard":                  {Tok: makeResource(datadogMod, "Dashboard")},

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -1,4 +1,4 @@
-> This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-datadog)
+> This provider is a derived work of the [Terraform Provider](https://github.com/DataDog/terraform-provider-datadog)
 > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
 > first check the [`pulumi-datadog` repo](https://github.com/pulumi/pulumi-datadog/issues); however, if that doesn't turn up anything,
-> please consult the source [`terraform-provider-datadog` repo](https://github.com/terraform-providers/terraform-provider-datadog/issues).
+> please consult the source [`terraform-provider-datadog` repo](https://github.com/DataDog/terraform-provider-datadog/issues).

--- a/sdk/python/pulumi_datadog/README.md
+++ b/sdk/python/pulumi_datadog/README.md
@@ -1,4 +1,4 @@
-> This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-datadog)
+> This provider is a derived work of the [Terraform Provider](https://github.com/DataDog/terraform-provider-datadog)
 > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
 > first check the [`pulumi-datadog` repo](https://github.com/pulumi/pulumi-datadog/issues); however, if that doesn't turn up anything,
-> please consult the source [`terraform-provider-datadog` repo](https://github.com/terraform-providers/terraform-provider-datadog/issues).
+> please consult the source [`terraform-provider-datadog` repo](https://github.com/DataDog/terraform-provider-datadog/issues).


### PR DESCRIPTION
Fixes #395.

With this change, the upgrader can successfully fetch new versions from upstream at github.com/DataDog/terraform-provider-datadog.
