### PR TITLE
Move off of old token mapping

### DIFF
--- a/provider/cmd/pulumi-resource-datadog/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-datadog/bridge-metadata.json
@@ -9772,11 +9772,9 @@
                 "majorVersion": 4,
                 "fields": {
                     "monitor_identifier": {
-                        "elem": {
-                            "fields": {
-                                "monitor_tags": {
-                                    "maxItemsOne": false
-                                }
+                        "fields": {
+                            "monitor_tags": {
+                                "maxItemsOne": false
                             }
                         }
                     },
@@ -9787,11 +9785,9 @@
                         "maxItemsOne": false
                     },
                     "recurring_schedule": {
-                        "elem": {
-                            "fields": {
-                                "recurrence": {
-                                    "maxItemsOne": false
-                                }
+                        "fields": {
+                            "recurrence": {
+                                "maxItemsOne": false
                             }
                         }
                     }
@@ -13836,17 +13832,15 @@
                     "host_list": {
                         "maxItemsOne": false,
                         "elem": {
-                            "elem": {
-                                "fields": {
-                                    "aliases": {
-                                        "maxItemsOne": false
-                                    },
-                                    "apps": {
-                                        "maxItemsOne": false
-                                    },
-                                    "sources": {
-                                        "maxItemsOne": false
-                                    }
+                            "fields": {
+                                "aliases": {
+                                    "maxItemsOne": false
+                                },
+                                "apps": {
+                                    "maxItemsOne": false
+                                },
+                                "sources": {
+                                    "maxItemsOne": false
                                 }
                             }
                         }
@@ -14338,6 +14332,17 @@
                     "users": {
                         "maxItemsOne": false
                     }
+                }
+            }
+        }
+    },
+    "auto-settings": {
+        "resources": {
+            "datadog_monitor": {
+                "maxItemsOneOverrides": {
+                    "scheduling_options": false,
+                    "scheduling_options.$.custom_schedule": false,
+                    "scheduling_options.$.evaluation_window": false
                 }
             }
         }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pulumi/pulumi-datadog/provider/v4/pkg/version"
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/x"
+	tks "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -218,7 +218,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 	}
 
-	strategy := x.TokensKnownModules("datadog_", datadogMod, []string{
+	strategy := tks.KnownModules("datadog_", datadogMod, []string{
 		"integration",
 	},
 		func(module, name string) (string, error) {
@@ -254,11 +254,9 @@ func Provider() tfbridge.ProviderInfo {
 			lower := string(unicode.ToLower(rune(name[0]))) + name[1:]
 			return datadogPkg + ":" + module + "/" + lower + ":" + name, nil
 		})
-	err := x.ComputeDefaults(&prov, strategy)
-	contract.AssertNoErrorf(err, "failed to apply mapping strategy")
 
-	err = x.AutoAliasing(&prov, prov.GetMetadata())
-	contract.AssertNoErrorf(err, "failed to apply token aliasing")
+	prov.MustComputeTokens(strategy)
+	prov.MustApplyAutoAliases()
 
 	return prov
 }


### PR DESCRIPTION
This fixes a bug in schema traversal, unblocking
https://github.com/pulumi/pulumi-terraform-bridge/pull/1758.