### PR TITLE
Fix random name test

### DIFF
--- a/provider/test-programs/index_logsindex/Pulumi.yaml
+++ b/provider/test-programs/index_logsindex/Pulumi.yaml
@@ -9,7 +9,7 @@ configuration: {}
 resources:
   my-datadog-logs-index:
     properties:
-      name: ${randomName.result}
+      name: a${randomName.result}
       disableDailyLimit: false
       filters:
         - query: source:python


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-datadog/issues/509

The resource was assigned a random name but it must start with a lower-case letter - it passed randomly in the PR.