### PR TITLE
Enable zero default schema version for datadog

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -170,6 +170,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			Namespaces: namespaceMap,
 		},
+		Ena
 	}
 
 	strategy := tks.KnownModules("datadog_", mainMod, []string{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -170,7 +170,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			Namespaces: namespaceMap,
 		},
-		Ena
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	strategy := tks.KnownModules("datadog_", mainMod, []string{


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133

Enables zero default schema version for datadog.