### PR TITLE
Improve AWS GovCloud Support - Add `accessKeyId` to `LogsArchiveS3Archive`

### DIFF
--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -8640,6 +8640,10 @@ export interface LogsArchiveS3Archive {
      * Your AWS role name
      */
     roleName: pulumi.Input<string>;
+    /**
+     * Your AWS access key id
+     */
+    accessKeyId: pulumi.Input<string>;
 }
 
 export interface LogsCustomDestinationElasticsearchDestination {


### PR DESCRIPTION
## Why

You cannot use Pulumi to create a Datadog `LogArchive` with an AWS GovCloud account as the destination. 

To use AWS GovCloud with Datadog, you [must use Access Key/Secret authentication, not roles](https://docs.datadoghq.com/integrations/amazon_web_services/#manual). This becomes blocked because the input argument for the resource does not include an option for `accessKeyId`. 

## What

- Add `accessKeyId` to the `LogsArchiveS3Archive` type
