### PR TITLE
Set `.DisplayName` in `tfbridge.ProviderInfo`

### DIFF
--- a/provider/cmd/pulumi-resource-datadog/schema.json
+++ b/provider/cmd/pulumi-resource-datadog/schema.json
@@ -1,5 +1,6 @@
 {
     "name": "datadog",
+    "displayName": "Datadog",
     "description": "A Pulumi package for creating and managing Datadog resources.",
     "keywords": [
         "pulumi",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -89,6 +89,7 @@ func Provider() tfbridge.ProviderInfo {
 	prov := tfbridge.ProviderInfo{
 		P:                   p,
 		Name:                "datadog",
+		DisplayName:         "Datadog",
 		Description:         "A Pulumi package for creating and managing Datadog resources.",
 		Keywords:            []string{"pulumi", "datadog"},
 		License:             "Apache-2.0",


### PR DESCRIPTION
This PR is part of pulumi/registry#4672. The display name used was taken from `github.com/pulumi/registry/tools/resourcedocsgen/pkg/lookup.go`.