### PR TITLE
enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -166,6 +166,7 @@ func Provider() tfbridge.ProviderInfo {
 			Namespaces: namespaceMap,
 		},
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	strategy := tks.KnownModules("datadog_", mainMod, []string{


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the pulumi-datadog provider. This should improve the quality of our previews for the provider.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2598