### PR TITLE
chore: fix panic in psed for tfgen

### DIFF
--- a/provider/dashboard.go
+++ b/provider/dashboard.go
@@ -114,6 +114,10 @@ typ:
 	// type references.
 
 	fixup := func(t *schema.TypeSpec) {
+		if t == nil {
+			return
+		}
+
 		const prefix = "#/types/"
 
 		tokStr, ok := strings.CutPrefix(t.Ref, prefix)


### PR DESCRIPTION
In an upcoming bridge release we have added a new Call() method on explicit providers. This is somewhat new functionality and it defeats the experimental code in datadog that is used to reduce accidental recursive type explosion. Adding a quick workaround that permits the code to succeed even with the new bridge.