### PR TITLE
Fix conflicts in GCP test

### DIFF
--- a/provider/test-programs/gcp_integration/Pulumi.yaml
+++ b/provider/test-programs/gcp_integration/Pulumi.yaml
@@ -6,7 +6,9 @@ config:
     value:
       pulumi:template: https://www.pulumi.com/ai/api/project/58803dd4-776b-4b7c-ac10-87d1928a6cb6.zip
 resources:
+  clientEmail:
+    type: random:RandomPet
   datadogGcpIntegration:
     properties:
-      clientEmail: your-client-email@example.com
+      clientEmail: ${clientEmail.id}@example.com
     type: datadog:gcp/integrationSts:IntegrationSts


### PR DESCRIPTION
This test is currently flaky when run in CI because multiple jobs
attempt to register the same service account email with the Datadog GCP
integration. These changes fix the flakes by using a random pet name for
the account's email.

Related to #1048.
